### PR TITLE
update default log location to local folder.

### DIFF
--- a/azkaban-exec-server/src/main/bash/start-exec.sh
+++ b/azkaban-exec-server/src/main/bash/start-exec.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 script_dir=$(dirname $0)
+script_parent_dir=$(dirname $script_dir)
 
 # pass along command line arguments to the internal launch script.
-${script_dir}/internal/internal-start-executor.sh "$@" >executorServerLog__`date +%F+%T`.out 2>&1 &
+${script_dir}/internal/internal-start-executor.sh "$@" > ${script_parent_dir}/local/executorServerLog__`date +%F+%T`.out 2>&1 &
 

--- a/azkaban-solo-server/src/main/bash/start-solo.sh
+++ b/azkaban-solo-server/src/main/bash/start-solo.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 script_dir=$(dirname $0)
+script_parent_dir=$(dirname $script_dir)
 
-${script_dir}/internal/internal-start-solo-server.sh "$@" > soloServerLog__`date +%F+%T`.out 2>&1 &
+${script_dir}/internal/internal-start-solo-server.sh "$@" > ${script_parent_dir}/local/soloServerLog__`date +%F+%T`.out 2>&1 &

--- a/azkaban-web-server/src/main/bash/start-web.sh
+++ b/azkaban-web-server/src/main/bash/start-web.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 script_dir=$(dirname $0)
+script_parent_dir=$(dirname $script_dir)
 
-${script_dir}/internal/internal-start-web.sh >webServerLog_`date +%F+%T`.out 2>&1 &
+${script_dir}/internal/internal-start-web.sh > ${script_parent_dir}/local/webServerLog_`date +%F+%T`.out 2>&1 &

--- a/docs/getStarted.rst
+++ b/docs/getStarted.rst
@@ -108,6 +108,7 @@ Inside the ``conf`` directory, there should be three files:
 - ``azkaban.properties`` - Used by Azkaban for runtime parameters
 - ``global.properties`` - Global static properties that are passed as shared properties to every workflow and job.
 - ``azkaban-users.xml`` - Used to add users and roles for authentication. This file is not used if the XmLUserManager is not set up to use it.
+- ``log4j.properties`` - is a optional configuration file for server log. If this configuration file is missing, the default log location is under ``local`` directory
 
 The ``The azkaban.properties`` file is the main configuration file.
 


### PR DESCRIPTION
Currently, the default log location is under server parent location. So the user will see folder structure like following
bin/
conf/
local/
soloServerLog__2019-11-02+01:05:42.out
soloServerLog__2019-11-02+01:56:07.out

1. Update the default log location to local/ folder
2. Update the getStarted doc to show how to config log configuration